### PR TITLE
chore: patch release 0.1.1 (core/server/cli)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@expo-up/typescript-config"]
+  "ignore": [
+    "@expo-up/typescript-config",
+    "example-expo-app",
+    "example-hono-cf-worker"
+  ]
 }

--- a/apps/example-hono-cf-worker/package.json
+++ b/apps/example-hono-cf-worker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-hono-cf-worker",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",


### PR DESCRIPTION
## Summary
- add a patch changeset for @expo-up/core, @expo-up/server, and @expo-up/cli
- prevent example app workspaces from being published by changesets

## Why
- enable patch release flow
- fix publish-next failure caused by app workspace publish attempts