### PR TITLE
fix(ci): stabilize publish-next with changesets and trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -117,7 +116,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -145,7 +143,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun


### PR DESCRIPTION
## Summary
- prevent example app workspaces from being published by changesets
- keep example worker package private
- remove npm token registry wiring from publish/version workflows so Trusted Publishing uses OIDC mode

## Why
- fix Publish Next (main) failures
- ensure only publishable packages (`@expo-up/core`, `@expo-up/server`, `@expo-up/cli`) are released
- avoid token-auth fallback in trusted publish workflows