### PR TITLE
fix(ci): trusted publishing alignment for npm OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    environment: npm-publish
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,6 +90,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -108,6 +110,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    environment: npm-publish
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,6 +119,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -135,6 +139,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    environment: npm-publish
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -143,6 +148,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun


### PR DESCRIPTION
## Summary
- add `environment: npm-publish` to publish jobs
- set npm registry in `setup-node` for publish jobs
- keep OIDC publish mode (`id-token: write`, no explicit npm token env)

## Why
- align workflow identity with npm Trusted Publisher configuration
- fix ENEEDAUTH failures in publish-next workflow

## npm Trusted Publisher fields
- Publisher: GitHub Actions
- Organization/user: glncy
- Repository: expo-up
- Workflow filename: publish.yml
- Environment name: npm-publish