### PR TITLE
fix(ci): force OIDC trusted publishing in npm release jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -101,6 +100,7 @@ jobs:
       - name: Publish snapshot next versions from changesets
         env:
           NPM_CONFIG_PROVENANCE: "true"
+          NODE_AUTH_TOKEN: ""
         run: bun run release:next
 
   publish-rc:
@@ -119,7 +119,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -130,6 +129,7 @@ jobs:
       - name: Publish snapshot rc versions from changesets
         env:
           NPM_CONFIG_PROVENANCE: "true"
+          NODE_AUTH_TOKEN: ""
         run: bun run release:rc
 
   publish-latest:
@@ -148,7 +148,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -159,4 +158,5 @@ jobs:
       - name: Publish latest from versioned packages
         env:
           NPM_CONFIG_PROVENANCE: "true"
+          NODE_AUTH_TOKEN: ""
         run: bun run release


### PR DESCRIPTION
## Summary
- prevent token-auth fallback in npm publish jobs
- clear inherited NODE_AUTH_TOKEN in publish steps
- keep OIDC trusted publishing path for next/rc/latest

## Why
publish-next jobs still injected NODE_AUTH_TOKEN from runner/repo context, causing npm to use token auth instead of trusted publishing OIDC.

## Notes
- workflow filename: publish.yml
- environment: npm-publish
- permissions include id-token: write