### PR TITLE
ci: improve npm trusted publish compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -119,6 +123,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun
@@ -148,6 +156,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Setup workspace
         uses: ./.github/actions/setup-bun


### PR DESCRIPTION
## Summary
- add npm registry URL in publish job setup-node steps
- upgrade npm to latest in publish jobs before changeset publish
- keep OIDC trusted publish settings (`id-token: write`, `environment: npm-publish`)

## Why
latest runs still fail with ENEEDAUTH despite trusted publisher setup. this change aligns runtime npm behavior with trusted publishing requirements.