### PR TITLE
fix(publish): add package repository metadata for npm provenance

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,10 @@
   "name": "@expo-up/cli",
   "version": "0.1.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glncy/expo-up"
+  },
   "bin": {
     "expo-up": "dist/index.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,10 @@
   "name": "@expo-up/core",
   "version": "0.1.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glncy/expo-up"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@expo-up/server",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glncy/expo-up"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/server/src/index.d.ts",


### PR DESCRIPTION
## Summary
- add `repository` metadata to `@expo-up/core`, `@expo-up/server`, and `@expo-up/cli`

## Why
npm trusted publishing provenance validation now requires package repository metadata to match the source repository. publish-next failed with:

`Error verifying sigstore provenance bundle: package.json repository.url is "", expected https://github.com/glncy/expo-up`