### PR TITLE
feat(cli): add CI token auth and CLI patch changeset

### DIFF
--- a/.changeset/short-pandas-chew.md
+++ b/.changeset/short-pandas-chew.md
@@ -1,0 +1,5 @@
+---
+"@expo-up/cli": patch
+---
+
+Add CI-friendly token auth support (`--token`, `EXPO_UP_CLI_GITHUB_TOKEN`), and improve CLI runtime/package reliability for external projects.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,6 +17,19 @@ CLI package for managing self-hosted Expo OTA workflows.
 
 - `--debug`: enable verbose logs for API calls, release diffing, and error context.
 
+## CI/CD Token Auth
+
+For non-interactive environments, use:
+- `EXPO_UP_CLI_GITHUB_TOKEN` (recommended)
+- or `--token` per command
+- token must have **write access** to your GitHub storage repository (contents write).
+
+Example:
+
+```bash
+EXPO_UP_CLI_GITHUB_TOKEN=ghp_xxx expo-up release --channel main --platform all
+```
+
 ## Command Reference
 
 ### `expo-up login`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -36,6 +36,9 @@ EXPO_UP_CLI_GITHUB_TOKEN=ghp_xxx expo-up release --channel main --platform all
 
 Authenticate and store local token/config for subsequent commands.
 
+Options:
+- `-t, --token <token>` save token directly (skip OAuth browser flow)
+
 ### `expo-up logout`
 
 Clear locally stored token/config session.
@@ -64,6 +67,9 @@ expo-up set-channel staging
 
 List available channels from the storage repository.
 
+Options:
+- `-t, --token <token>` use GitHub token directly (CI-friendly)
+
 ### `expo-up release`
 
 Build and upload a new OTA build for a channel/runtime.
@@ -71,6 +77,7 @@ Build and upload a new OTA build for a channel/runtime.
 Options:
 - `--platform <ios|android|all>` default: `all`
 - `--channel <name>` optional channel override
+- `-t, --token <token>` use GitHub token directly (CI-friendly)
 - channel defaults to `main` when no saved/override channel is provided
 
 Behavior:
@@ -84,6 +91,7 @@ Examples:
 
 ```bash
 expo-up release --platform all --channel main
+expo-up release -t "$EXPO_UP_CLI_GITHUB_TOKEN" --platform all --channel main
 expo-up --debug release --platform ios --channel feat/new-home
 ```
 
@@ -96,12 +104,14 @@ Options:
 - `--delete <buildIds...>` non-interactive delete mode (CI friendly)
 - `--yes` skip confirmation for delete mode
 - `--no-interactive-delete` disable TUI selection mode
+- `-t, --token <token>` use GitHub token directly (CI-friendly)
 - channel defaults to `main` when no saved/override channel is provided
 
 Examples:
 
 ```bash
 expo-up history --channel main
+expo-up history -t "$EXPO_UP_CLI_GITHUB_TOKEN" --channel main
 expo-up history --channel main --delete 10 11 --yes
 ```
 
@@ -111,7 +121,8 @@ Rollback channel to previous build or embedded app update.
 
 Options:
 - `--channel <name>` optional channel override
-- `--to <buildId>` rollback target build
+- `-b, --to <buildId>` rollback target build
+- `-t, --token <token>` use GitHub token directly (CI-friendly)
 - `--embedded` rollback to embedded/native update
 - channel defaults to `main` when no saved/override channel is provided
 
@@ -119,6 +130,7 @@ Examples:
 
 ```bash
 expo-up rollback --channel main --to 10
+expo-up rollback -t "$EXPO_UP_CLI_GITHUB_TOKEN" --channel main -b 10
 expo-up rollback --channel main --embedded
 ```
 

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -81,7 +81,13 @@ export function writeConfig(data: Partial<StoredConfig>): void {
   ensureConfigIgnored(EXPO_UP_CONFIG_RELATIVE_PATH);
 }
 
-export async function login() {
+export async function login(token?: string) {
+  if (token?.trim()) {
+    writeConfig({ github_token: token.trim() });
+    console.log(`\n${pc.green("✔")} Token saved.`);
+    return token.trim();
+  }
+
   const { serverUrl } = getAutoConfig();
   if (!serverUrl) throw new Error(`Server URL not found in expo config.`);
 
@@ -123,6 +129,17 @@ export async function login() {
 export function getStoredToken() {
   return readConfig().github_token;
 }
+
+export function resolveGithubToken(token?: string): string | undefined {
+  const explicit = token?.trim();
+  if (explicit) return explicit;
+
+  const envToken = process.env.EXPO_UP_CLI_GITHUB_TOKEN?.trim();
+  if (envToken) return envToken;
+
+  return getStoredToken();
+}
+
 export function getStoredChannel() {
   return readConfig().channel || DEFAULT_CHANNEL;
 }

--- a/packages/cli/src/channels.tsx
+++ b/packages/cli/src/channels.tsx
@@ -2,16 +2,22 @@ import * as React from "react";
 import { Text, Box } from "ink";
 import Spinner from "ink-spinner";
 import { Octokit } from "@octokit/rest";
-import { getStoredToken, getAutoConfig, getStoredChannel } from "./auth";
+import {
+  getAutoConfig,
+  getStoredChannel,
+  resolveGithubToken,
+} from "./auth";
 import { INIT_CHANNEL, parseProjectDescriptor } from "../../core/src/index";
 import { Badge, BrandHeader, CliCard, KV } from "./ui";
 
 interface ListChannelsProps {
   debug?: boolean;
+  token?: string;
 }
 
 export const ListChannels: React.FC<ListChannelsProps> = ({
   debug = false,
+  token,
 }) => {
   const [channels, setChannels] = React.useState<string[]>([]);
   const [loading, setLoading] = React.useState(true);
@@ -23,10 +29,10 @@ export const ListChannels: React.FC<ListChannelsProps> = ({
       try {
         const appendDebug = (message: string): void =>
           setDebugLogs((prev) => [...prev, message]);
-        const token = getStoredToken();
+        const resolvedToken = resolveGithubToken(token);
         const { serverUrl, projectId } = getAutoConfig();
 
-        if (!token || !serverUrl || !projectId)
+        if (!resolvedToken || !serverUrl || !projectId)
           throw new Error("Missing configuration. Are you logged in?");
         if (debug)
           appendDebug(
@@ -38,7 +44,7 @@ export const ListChannels: React.FC<ListChannelsProps> = ({
 
         const { owner, repo } = parseProjectDescriptor(await projRes.json());
 
-        const octokit = new Octokit({ auth: token });
+        const octokit = new Octokit({ auth: resolvedToken });
         const { data: branches } = await octokit.repos.listBranches({
           owner,
           repo,
@@ -60,7 +66,7 @@ export const ListChannels: React.FC<ListChannelsProps> = ({
       }
     };
     run();
-  }, [debug]);
+  }, [debug, token]);
 
   const currentChannel = getStoredChannel();
 

--- a/packages/cli/src/channels.tsx
+++ b/packages/cli/src/channels.tsx
@@ -2,11 +2,7 @@ import * as React from "react";
 import { Text, Box } from "ink";
 import Spinner from "ink-spinner";
 import { Octokit } from "@octokit/rest";
-import {
-  getAutoConfig,
-  getStoredChannel,
-  resolveGithubToken,
-} from "./auth";
+import { getAutoConfig, getStoredChannel, resolveGithubToken } from "./auth";
 import { INIT_CHANNEL, parseProjectDescriptor } from "../../core/src/index";
 import { Badge, BrandHeader, CliCard, KV } from "./ui";
 

--- a/packages/cli/src/history.tsx
+++ b/packages/cli/src/history.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Text, Box, useInput } from "ink";
 import Spinner from "ink-spinner";
 import { Octokit } from "@octokit/rest";
-import { getStoredToken, getAutoConfig } from "./auth";
+import { getAutoConfig, resolveGithubToken } from "./auth";
 import {
   EMBEDDED_ROLLBACK_TARGET,
   parseProjectDescriptor,
@@ -16,6 +16,7 @@ interface HistoryProps {
   deleteBuildIds?: string[];
   interactiveDelete?: boolean;
   yes?: boolean;
+  token?: string;
 }
 
 type BuildItem = {
@@ -44,6 +45,7 @@ export const History: React.FC<HistoryProps> = ({
   deleteBuildIds,
   interactiveDelete = true,
   yes = false,
+  token,
 }) => {
   const [items, setItems] = React.useState<BuildItem[]>([]);
   const [status, setStatus] = React.useState<HistoryStatus>("loading");
@@ -94,11 +96,13 @@ export const History: React.FC<HistoryProps> = ({
       setSelectedBuilds(new Set());
       setCursor(0);
 
-      const token = getStoredToken();
+      const resolvedToken = resolveGithubToken(token);
       const { serverUrl, projectId, runtimeVersion } = getAutoConfig();
 
-      if (!token || !serverUrl || !projectId || !runtimeVersion) {
-        throw new Error("Missing configuration. Are you logged in?");
+      if (!resolvedToken || !serverUrl || !projectId || !runtimeVersion) {
+        throw new Error(
+          'Missing configuration. Use "login", --token, or EXPO_UP_CLI_GITHUB_TOKEN.',
+        );
       }
       if (debug) {
         appendDebug(
@@ -106,7 +110,7 @@ export const History: React.FC<HistoryProps> = ({
         );
       }
 
-      const octokit = new Octokit({ auth: token });
+      const octokit = new Octokit({ auth: resolvedToken });
 
       const projRes = await fetch(`${serverUrl}/projects/${projectId}`);
       if (!projRes.ok) throw new Error(`Project "${projectId}" not found.`);
@@ -200,7 +204,7 @@ export const History: React.FC<HistoryProps> = ({
       setStatus("error");
       if (debug) appendDebug(`Failure: ${message}`);
     }
-  }, [appendDebug, channel, debug]);
+  }, [appendDebug, channel, debug, token]);
 
   const deleteBuilds = React.useCallback(
     async (buildIds: number[]) => {

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -142,8 +142,8 @@ program
   .command("rollback")
   .description("Rollback to a previous build")
   .option("-c, --channel <channel>", "Override active channel")
-  .option("-t, --to <build>", "Specific build ID")
-  .option("--token <token>", "Use GitHub token directly (CI-friendly)")
+  .option("-b, --to <build>", "Specific build ID")
+  .option("-t, --token <token>", "Use GitHub token directly (CI-friendly)")
   .option("-e, --embedded", "Rollback to native build")
   .action((options) => {
     const channel = options.channel || getStoredChannel() || DEFAULT_CHANNEL;
@@ -172,7 +172,7 @@ program
     "--no-interactive-delete",
     "Disable interactive multi-select delete mode for build history",
   )
-  .option("--token <token>", "Use GitHub token directly (CI-friendly)")
+  .option("-t, --token <token>", "Use GitHub token directly (CI-friendly)")
   .action((options) => {
     const channel = options.channel || getStoredChannel() || DEFAULT_CHANNEL;
     const debug = program.opts().debug;

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -8,7 +8,7 @@ import { stdin as input, stdout as output } from "node:process";
 import {
   login,
   logout,
-  getStoredToken,
+  resolveGithubToken,
   writeConfig,
   getStoredChannel,
   getAutoConfig,
@@ -62,18 +62,21 @@ program
 program
   .command("list-channels")
   .description("List available channels in your storage repository")
-  .action(() => {
+  .option("-t, --token <token>", "Use GitHub token directly (CI-friendly)")
+  .action((options) => {
     const debug = program.opts().debug;
-    render(<ListChannels debug={debug} />);
+    render(<ListChannels debug={debug} token={options.token} />);
   });
 
 // --- AUTH COMMANDS ---
 program
   .command("login")
   .description("Authenticate with GitHub")
+  .option("-t, --token <token>", "Save GitHub token without OAuth browser flow")
   .action(
-    withCommandErrorBoundary(async () => {
-      await login();
+    withCommandErrorBoundary(async (options: Record<string, unknown>) => {
+      const token = typeof options.token === "string" ? options.token : "";
+      await login(token);
       process.exit(0);
     }),
   );
@@ -90,7 +93,7 @@ program
   .command("whoami")
   .description("Check currently logged in session and project info")
   .action(() => {
-    const token = getStoredToken();
+    const token = resolveGithubToken();
     const { serverUrl, projectId } = getAutoConfig();
     const channel = getStoredChannel();
 
@@ -120,11 +123,19 @@ program
   .description("Bundle and upload an update")
   .option("-p, --platform <platform>", "ios, android, or all", "all")
   .option("-c, --channel <channel>", "Override active channel")
+  .option("-t, --token <token>", "Use GitHub token directly (CI-friendly)")
   .action((options) => {
     const channel = options.channel || getStoredChannel() || DEFAULT_CHANNEL;
     const platform = parsePlatform(options.platform);
     const debug = program.opts().debug;
-    render(<Release channel={channel} platform={platform} debug={debug} />);
+    render(
+      <Release
+        channel={channel}
+        platform={platform}
+        debug={debug}
+        token={options.token}
+      />,
+    );
   });
 
 program
@@ -132,6 +143,7 @@ program
   .description("Rollback to a previous build")
   .option("-c, --channel <channel>", "Override active channel")
   .option("-t, --to <build>", "Specific build ID")
+  .option("--token <token>", "Use GitHub token directly (CI-friendly)")
   .option("-e, --embedded", "Rollback to native build")
   .action((options) => {
     const channel = options.channel || getStoredChannel() || DEFAULT_CHANNEL;
@@ -142,6 +154,7 @@ program
         to={options.to}
         embedded={options.embedded}
         debug={debug}
+        token={options.token}
       />,
     );
   });
@@ -159,6 +172,7 @@ program
     "--no-interactive-delete",
     "Disable interactive multi-select delete mode for build history",
   )
+  .option("--token <token>", "Use GitHub token directly (CI-friendly)")
   .action((options) => {
     const channel = options.channel || getStoredChannel() || DEFAULT_CHANNEL;
     const debug = program.opts().debug;
@@ -169,6 +183,7 @@ program
         deleteBuildIds={options.delete}
         interactiveDelete={options.interactiveDelete}
         yes={options.yes}
+        token={options.token}
       />,
     );
   });

--- a/packages/cli/src/release.tsx
+++ b/packages/cli/src/release.tsx
@@ -7,7 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 import pc from "picocolors";
 import { spawnSync } from "node:child_process";
-import { getAutoConfig, getStoredToken } from "./auth";
+import { getAutoConfig, resolveGithubToken } from "./auth";
 import { INIT_CHANNEL, parseProjectDescriptor } from "../../core/src/index";
 import { Badge, BrandHeader, CliCard, KV } from "./ui";
 import { PlatformOption } from "./cli-utils";
@@ -24,6 +24,7 @@ interface ReleaseProps {
   channel?: string;
   platform: PlatformOption;
   debug?: boolean;
+  token?: string;
 }
 
 interface GitRefResponse {
@@ -60,6 +61,7 @@ export const Release: React.FC<ReleaseProps> = ({
   channel = "main",
   platform,
   debug = false,
+  token,
 }) => {
   const [status, setStatus] = useState<ReleaseStatus>("idle");
   const [logs, setLogs] = useState<string[]>([]);
@@ -103,8 +105,11 @@ export const Release: React.FC<ReleaseProps> = ({
     const run = async () => {
       try {
         const config = getAutoConfig();
-        const token = getStoredToken();
-        if (!token) throw new Error('Not logged in. Run "login" first.');
+        const resolvedToken = resolveGithubToken(token);
+        if (!resolvedToken)
+          throw new Error(
+            'Missing GitHub token. Use "login", --token, or EXPO_UP_CLI_GITHUB_TOKEN.',
+          );
         if (!config.serverUrl || !config.projectId || !config.runtimeVersion) {
           throw new Error(
             "Missing Expo updates configuration. Check Expo config updates.url and version.",
@@ -118,7 +123,7 @@ export const Release: React.FC<ReleaseProps> = ({
           throw new Error(`Project "${config.projectId}" not found on server.`);
         const { owner, repo } = parseProjectDescriptor(await projectRes.json());
 
-        const octokit = new Octokit({ auth: token });
+        const octokit = new Octokit({ auth: resolvedToken });
 
         setStatus("exporting");
         appendLog(
@@ -456,7 +461,7 @@ export const Release: React.FC<ReleaseProps> = ({
     };
 
     run();
-  }, [channel, platform]);
+  }, [channel, debug, platform, token]);
 
   return (
     <Box flexDirection="column" padding={1}>

--- a/packages/cli/src/rollback.tsx
+++ b/packages/cli/src/rollback.tsx
@@ -3,7 +3,7 @@ import { Text, Box, Static } from "ink";
 import Spinner from "ink-spinner";
 import { Octokit } from "@octokit/rest";
 import pc from "picocolors";
-import { getStoredToken, getAutoConfig } from "./auth";
+import { getAutoConfig, resolveGithubToken } from "./auth";
 import {
   EMBEDDED_ROLLBACK_TARGET,
   parseProjectDescriptor,
@@ -17,6 +17,7 @@ interface RollbackProps {
   to?: string;
   embedded?: boolean;
   debug?: boolean;
+  token?: string;
 }
 
 export const Rollback: React.FC<RollbackProps> = ({
@@ -24,6 +25,7 @@ export const Rollback: React.FC<RollbackProps> = ({
   to,
   embedded,
   debug = false,
+  token,
 }) => {
   const [logs, setLogs] = React.useState<string[]>([]);
   const [debugLogs, setDebugLogs] = React.useState<string[]>([]);
@@ -40,17 +42,19 @@ export const Rollback: React.FC<RollbackProps> = ({
           setLogs((prev) => [...prev, message]);
         const appendDebug = (message: string): void =>
           setDebugLogs((prev) => [...prev, message]);
-        const token = getStoredToken();
+        const resolvedToken = resolveGithubToken(token);
         const { serverUrl, projectId, runtimeVersion } = getAutoConfig();
 
-        if (!token || !serverUrl || !projectId || !runtimeVersion)
-          throw new Error("Missing configuration.");
+        if (!resolvedToken || !serverUrl || !projectId || !runtimeVersion)
+          throw new Error(
+            'Missing configuration. Use "login", --token, or EXPO_UP_CLI_GITHUB_TOKEN.',
+          );
         if (debug)
           appendDebug(
             `Resolved config: server=${serverUrl}, project=${projectId}, runtime=${runtimeVersion}`,
           );
 
-        const octokit = new Octokit({ auth: token });
+        const octokit = new Octokit({ auth: resolvedToken });
         setStatus("running");
 
         const projRes = await fetch(`${serverUrl}/projects/${projectId}`);
@@ -190,7 +194,7 @@ export const Rollback: React.FC<RollbackProps> = ({
       }
     };
     run();
-  }, [channel, debug, embedded, to]);
+  }, [channel, debug, embedded, to, token]);
 
   return (
     <Box flexDirection="column" padding={1}>


### PR DESCRIPTION
## Summary
- add CI-friendly token auth for CLI commands via `--token`
- add env token support via `EXPO_UP_CLI_GITHUB_TOKEN`
- remove legacy `EXPO_UP_GITHUB_TOKEN` fallback
- document token requirements in CLI README (write access to storage repo)
- include CLI patch changeset only

## Validation
- `cd packages/cli && bun run check-types`
- `cd packages/cli && bun run test`

## Changeset
- `.changeset/short-pandas-chew.md` bumps `@expo-up/cli` as patch
