### PR TITLE
fix(cli): exit history in CI environments

### DIFF
--- a/.changeset/bright-coats-jump.md
+++ b/.changeset/bright-coats-jump.md
@@ -1,0 +1,5 @@
+---
+"@expo-up/cli": patch
+---
+
+Fix `expo-up history` so it exits cleanly in CI and non-interactive environments after printing results, while keeping the local interactive TUI behavior.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Shared reusable logic used by CLI/server.
 - `@expo-up/cli` depends on `@expo-up/core`.
 
 Publish order:
+
 1. `@expo-up/core`
 2. `@expo-up/server`
 3. `@expo-up/cli`
@@ -130,6 +131,7 @@ expo-up history --channel <name> --delete <ids...> --yes
 
 - View release/rollback timeline.
 - Interactive delete in TTY by default.
+- Prints once and exits automatically in CI/non-TTY environments.
 - CI-safe delete via `--delete` and `--yes`.
 
 ### Rollback
@@ -170,6 +172,7 @@ Default base path in examples: `/api/expo-up`
 ### `GET /api/expo-up/:projectId/manifest`
 
 Headers typically used by Expo client:
+
 - `expo-runtime-version` (required)
 - `expo-platform` (required)
 - `expo-channel-name` (optional)
@@ -178,6 +181,7 @@ Headers typically used by Expo client:
 - `expo-expect-signature` (optional)
 
 Behavior:
+
 - `200` multipart manifest when update is available
 - `200` rollback directive when channel resolves to embedded rollback
 - `204` when already up-to-date
@@ -220,6 +224,7 @@ bun run dev
 ```
 
 Set `.dev.vars`:
+
 - `GITHUB_AUTH_TOKEN`
 - `GITHUB_CLIENT_ID`
 - `GITHUB_CLIENT_SECRET`
@@ -246,6 +251,7 @@ bunx expo-up rollback --channel main --to <build-id>
 ```
 
 In app UI:
+
 - use `Fetch update`
 - use `Channel Surf`
 - verify update details/logs
@@ -269,6 +275,7 @@ bun run release
 Workflow: `.github/workflows/pr-quality.yml`
 
 On every pull request:
+
 1. `build` runs first
 2. `test`, `lint`, and `check-types` run in parallel after build passes
 3. Bun + Turbo caches are restored/saved for faster subsequent runs
@@ -297,6 +304,7 @@ Workflow: `.github/workflows/version-packages.yml`
 - When that PR is merged, package.json versions/changelogs are synced in the repo.
 
 Publish order is always:
+
 1. `@expo-up/core`
 2. `@expo-up/server`
 3. `@expo-up/cli`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,7 @@ CLI package for managing self-hosted Expo OTA workflows.
 ## CI/CD Token Auth
 
 For non-interactive environments, use:
+
 - `EXPO_UP_CLI_GITHUB_TOKEN` (recommended)
 - or `--token` per command
 - token must have **write access** to your GitHub storage repository (contents write).
@@ -37,6 +38,7 @@ EXPO_UP_CLI_GITHUB_TOKEN=ghp_xxx expo-up release --channel main --platform all
 Authenticate and store local token/config for subsequent commands.
 
 Options:
+
 - `-t, --token <token>` save token directly (skip OAuth browser flow)
 
 ### `expo-up logout`
@@ -46,6 +48,7 @@ Clear locally stored token/config session.
 ### `expo-up whoami`
 
 Print resolved project context:
+
 - projectId from Expo config
 - active channel
 - server URL
@@ -68,6 +71,7 @@ expo-up set-channel staging
 List available channels from the storage repository.
 
 Options:
+
 - `-t, --token <token>` use GitHub token directly (CI-friendly)
 
 ### `expo-up release`
@@ -75,12 +79,14 @@ Options:
 Build and upload a new OTA build for a channel/runtime.
 
 Options:
+
 - `--platform <ios|android|all>` default: `all`
 - `--channel <name>` optional channel override
 - `-t, --token <token>` use GitHub token directly (CI-friendly)
 - channel defaults to `main` when no saved/override channel is provided
 
 Behavior:
+
 1. Runs `expo export`.
 2. Reads local `dist/metadata.json`.
 3. Compares sorted metadata hash against latest remote build in the channel.
@@ -99,7 +105,13 @@ expo-up --debug release --platform ios --channel feat/new-home
 
 Show release/rollback timeline for a channel.
 
+Behavior:
+
+- local TTY: interactive history view with multi-select delete shortcuts
+- CI/non-TTY: prints the history once and exits automatically
+
 Options:
+
 - `--channel <name>` optional channel override
 - `--delete <buildIds...>` non-interactive delete mode (CI friendly)
 - `--yes` skip confirmation for delete mode
@@ -112,6 +124,7 @@ Examples:
 ```bash
 expo-up history --channel main
 expo-up history -t "$EXPO_UP_CLI_GITHUB_TOKEN" --channel main
+CI=true expo-up history -t "$EXPO_UP_CLI_GITHUB_TOKEN" --channel main
 expo-up history --channel main --delete 10 11 --yes
 ```
 
@@ -120,6 +133,7 @@ expo-up history --channel main --delete 10 11 --yes
 Rollback channel to previous build or embedded app update.
 
 Options:
+
 - `--channel <name>` optional channel override
 - `-b, --to <buildId>` rollback target build
 - `-t, --token <token>` use GitHub token directly (CI-friendly)
@@ -139,6 +153,7 @@ expo-up rollback --channel main --embedded
 Generate keypair/certificate and update Expo config for signed updates.
 
 Key options:
+
 - `--organization <name>`
 - `--certificate-validity-duration-years <years>`
 - `--key-id <id>` default: `main`

--- a/packages/cli/src/history-utils.test.ts
+++ b/packages/cli/src/history-utils.test.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../typescript-config/bun-test-shim.d.ts" />
 import { describe, expect, it } from "bun:test";
-import { parseDeleteBuildIds } from "./history-utils";
+import { parseDeleteBuildIds, shouldAutoExitHistory } from "./history-utils";
 
 describe("parseDeleteBuildIds", () => {
   it("returns empty array when values are missing", () => {
@@ -19,5 +19,71 @@ describe("parseDeleteBuildIds", () => {
     expect(() => parseDeleteBuildIds(["latest"])).toThrow(
       'Invalid build id "latest"',
     );
+  });
+});
+
+describe("shouldAutoExitHistory", () => {
+  it("does not auto-exit in interactive mode", () => {
+    expect(
+      shouldAutoExitHistory({
+        interactiveMode: true,
+        status: "idle",
+        hasPendingDeleteConfirmation: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-exit while work is still running", () => {
+    expect(
+      shouldAutoExitHistory({
+        interactiveMode: false,
+        status: "loading",
+        hasPendingDeleteConfirmation: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldAutoExitHistory({
+        interactiveMode: false,
+        status: "deleting",
+        hasPendingDeleteConfirmation: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-exit while waiting for delete confirmation", () => {
+    expect(
+      shouldAutoExitHistory({
+        interactiveMode: false,
+        status: "idle",
+        hasPendingDeleteConfirmation: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("auto-exits after non-interactive list or terminal states", () => {
+    expect(
+      shouldAutoExitHistory({
+        interactiveMode: false,
+        status: "idle",
+        hasPendingDeleteConfirmation: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoExitHistory({
+        interactiveMode: false,
+        status: "success",
+        hasPendingDeleteConfirmation: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoExitHistory({
+        interactiveMode: false,
+        status: "error",
+        hasPendingDeleteConfirmation: false,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/cli/src/history-utils.ts
+++ b/packages/cli/src/history-utils.ts
@@ -22,3 +22,17 @@ export function parseDeleteBuildIds(values?: string[]): number[] {
 
   return Array.from(new Set(parsed)).sort((a, b) => b - a);
 }
+
+export function shouldAutoExitHistory(options: {
+  interactiveMode: boolean;
+  status: "loading" | "idle" | "deleting" | "success" | "error";
+  hasPendingDeleteConfirmation: boolean;
+}): boolean {
+  const { interactiveMode, status, hasPendingDeleteConfirmation } = options;
+
+  if (interactiveMode || hasPendingDeleteConfirmation) {
+    return false;
+  }
+
+  return status !== "loading" && status !== "deleting";
+}

--- a/packages/cli/src/history.tsx
+++ b/packages/cli/src/history.tsx
@@ -321,8 +321,7 @@ export const History: React.FC<HistoryProps> = ({
     }
 
     didExitRef.current = true;
-    process.exitCode = error ? 1 : 0;
-    exit();
+    exit(error ? new Error(error) : undefined);
   }, [error, exit, interactiveMode, pendingDeleteIds, status]);
 
   React.useEffect(() => {

--- a/packages/cli/src/history.tsx
+++ b/packages/cli/src/history.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Text, Box, useInput } from "ink";
+import { Text, Box, useApp, useInput } from "ink";
 import Spinner from "ink-spinner";
 import { Octokit } from "@octokit/rest";
 import { getAutoConfig, resolveGithubToken } from "./auth";
@@ -8,7 +8,7 @@ import {
   parseProjectDescriptor,
 } from "../../core/src/index";
 import { Badge, BrandHeader, CliCard, KV } from "./ui";
-import { parseDeleteBuildIds } from "./history-utils";
+import { parseDeleteBuildIds, shouldAutoExitHistory } from "./history-utils";
 
 interface HistoryProps {
   channel: string;
@@ -47,6 +47,7 @@ export const History: React.FC<HistoryProps> = ({
   yes = false,
   token,
 }) => {
+  const { exit } = useApp();
   const [items, setItems] = React.useState<BuildItem[]>([]);
   const [status, setStatus] = React.useState<HistoryStatus>("loading");
   const [error, setError] = React.useState<string | null>(null);
@@ -62,6 +63,7 @@ export const History: React.FC<HistoryProps> = ({
 
   const ctxRef = React.useRef<HistoryContext | null>(null);
   const autoDeleteTriggeredRef = React.useRef(false);
+  const didExitRef = React.useRef(false);
 
   const parsedAutoDeleteIds = React.useMemo(() => {
     try {
@@ -302,6 +304,26 @@ export const History: React.FC<HistoryProps> = ({
   React.useEffect(() => {
     loadHistory();
   }, [loadHistory]);
+
+  React.useEffect(() => {
+    if (didExitRef.current) {
+      return;
+    }
+
+    if (
+      !shouldAutoExitHistory({
+        interactiveMode,
+        status,
+        hasPendingDeleteConfirmation: Boolean(pendingDeleteIds),
+      })
+    ) {
+      return;
+    }
+
+    didExitRef.current = true;
+    process.exitCode = error ? 1 : 0;
+    exit();
+  }, [error, exit, interactiveMode, pendingDeleteIds, status]);
 
   React.useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- make `expo-up history` exit automatically in CI and other non-interactive environments after it finishes loading or reaches a terminal state
- keep the local interactive TUI behavior unchanged and cover the new auto-exit decision with unit tests
- document the CI-friendly `history` behavior and add a changeset for the CLI patch release